### PR TITLE
use viewport units to prevent canvas from overflowing

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,9 @@
 
     /* ------ POSITION GAME-CANVAS ------ */
     canvas#canvas {
-      width: 512px; height: 512px;                /* max game size: 512px */
+      max-width: 512px;                           /* max game size: 512px */
+      width: 512px; height: 512px;
+      width: 100vmin;                             /* ensures the game won't overflow the screen */
       image-rendering: optimizeSpeed;
       image-rendering: -moz-crisp-edges;
       image-rendering: -webkit-optimize-contrast;
@@ -53,7 +55,7 @@
       border: 0;
     }
     @media screen and (max-width: 512px) {        /* game shrinks to fit screen on smaller screens */
-      canvas#canvas { width: 100%; height: auto; } }
+      canvas#canvas { width: 100%; height: auto; width: 100vmin} }
     .canvas-wrapper { text-align: center; }
     .canvas-wrapper canvas { margin: 0 auto; }    /* center game */
     @media screen and (min-height: 700px) {       /* game has top-margin on high screens */


### PR DESCRIPTION
this PR keeps the canvas from overflowing the screen in landscape mode.
I've kept the original widths to fall back to for browsers without viewport unit support.